### PR TITLE
A number of fixes to improve the library and get it working with React 0.16.

### DIFF
--- a/RCTTCPSocket.xcodeproj/project.pbxproj
+++ b/RCTTCPSocket.xcodeproj/project.pbxproj
@@ -164,6 +164,7 @@
 					"$(inherited)",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					"$(SRCROOT)/../../React/**",
+					"$(SRCROOT)/../react-native/React/**",
 					"\"$(SRCROOT)/../node_modules/react-native/React\"/**",
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 8.4;
@@ -218,6 +219,14 @@
 		CD35AD8A1B7488C10078B662 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
+					"$(SRCROOT)/../../React/**",
+					"$(SRCROOT)/node-modules/react-native/React/**",
+					"$(SRCROOT)/../react-native/React/**",
+					"\"$(SRCROOT)/../node_modules/react-native/React\"/**",
+				);
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;


### PR DESCRIPTION
- Switch to NSDictionary because React 0.16 no longer has RCTSparseArray.
- Correct base64 encoding to not include newlines.
- Use Buffer when available rather than ByteArray.
- After reading some data call read again to continue reading.
- Add additional header paths to find React.
- Add nonnull designations for NSNumber as required by react to ensure Android compatibility.
- Switch to app events because the events are not device dependent.
- Update React requires for latest style.
